### PR TITLE
Use GitHub lint binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
     "eslint-plugin-github": "^1.1.3",
     "rollup": "^0.64.0",
     "rollup-plugin-babel": "^3.0.7"
-  }
+  },
+  "eslintIgnore": [
+    "dist/",
+    "prettier.config.js"
+  ]
 }


### PR DESCRIPTION
Instead of invoking `eslint` and `flow` by ourselves we can do it via `github-lint`. This will mean that any updates that we want to do to our linting setup, we can do in `eslint-plugin-github` and just update that package in this repo and gain all the benefits from those changes.