### PR TITLE
Mark the package as side-effects free

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/textarea-autosize.umd.js",
   "module": "dist/textarea-autosize.esm.js",
   "types": "index.d.ts",
+  "side-effects": false,
   "license": "MIT",
   "repository": "github/textarea-autosize",
   "files": [


### PR DESCRIPTION
This helps Rollup and webpack when performing tree-shaking.