### PR TITLE
Account for 'border-box' box sizing in textarea height

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,15 @@ export default function autosize(textarea) {
       return
     }
 
-    const maxHeight = Number(getComputedStyle(textarea).height.replace(/px/, '')) + bottom
+    const textareaStyle = getComputedStyle(textarea)
+
+    const topBorderWidth = Number(textareaStyle.borderTopWidth.replace(/px/, ''))
+    const bottomBorderWidth = Number(textareaStyle.borderBottomWidth.replace(/px/, ''))
+
+    const isBorderBox = textareaStyle.boxSizing === 'border-box'
+    const borderAddOn = isBorderBox ? topBorderWidth + bottomBorderWidth : 0
+
+    const maxHeight = Number(textareaStyle.height.replace(/px/, '')) + bottom
     textarea.style.maxHeight = `${maxHeight - 100}px`
 
     const container = textarea.parentElement
@@ -56,7 +64,7 @@ export default function autosize(textarea) {
       const containerHeight = container.style.height
       container.style.height = getComputedStyle(container).height
       textarea.style.height = 'auto'
-      textarea.style.height = `${textarea.scrollHeight}px`
+      textarea.style.height = `${textarea.scrollHeight + borderAddOn}px`
       container.style.height = containerHeight
       height = textarea.style.height
     }


### PR DESCRIPTION
When setting the height of a textarea with 'border-box' box-sizing, that height will include the height of the top and bottom border width. 'scrollHeight', which we use for setting the textarea's height, does not include border size. This means, for 'border-box' textareas with >0-width borders, the height of the content itself will be less than it needs to be.

This results in a tiny bit of overflow, unnecessarily showing a scrollbar and capturing scroll input!

![textarea-autosize-bug-demo](https://user-images.githubusercontent.com/27496517/100459209-ffe33f80-30bc-11eb-901f-f99d0b2da8b5.gif)

This fix adds the textarea's top and bottom border width to the height we set the textarea to, _if_ its box-sizing is border-box.