### PR TITLE
Fix and parameterise bottom margin behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function autosize(textarea) {
+export default function autosize(textarea, {viewportMarginBottom = 100} = {}) {
   let previousValue = null
   let isUserResized = false
 
@@ -57,7 +57,8 @@ export default function autosize(textarea) {
     const borderAddOn = isBorderBox ? topBorderWidth + bottomBorderWidth : 0
 
     const maxHeight = Number(textareaStyle.height.replace(/px/, '')) + bottom
-    textarea.style.maxHeight = `${maxHeight - 100}px`
+    const adjustedViewportMarginBottom = bottom < viewportMarginBottom ? bottom : viewportMarginBottom
+    textarea.style.maxHeight = `${maxHeight - adjustedViewportMarginBottom}px`
 
     const container = textarea.parentElement
     if (container instanceof HTMLElement) {


### PR DESCRIPTION
Addresses #10.

This PR adds an optional 'viewportMarginBottom' parameter in place of the hardcoded 100px margin applied by the `maxHeight - 100` line. This margin controls how far the textarea is allowed to be resized relative to the bottom of the viewport.

Adding 'viewportMarginBottom' as an optional parameter means no interface change, so only a minor version bump's needed.

It also adds logic for handling the case where the textarea sits below this bottom viewport margin on the page, e.g. the textarea is 20px away from the bottom when the margin value is 100. Previously, this would cause buggy behavior where the flat ' - 100' would set the textarea's maxHeight to a negative value. 'adjustedViewportMarginBottom' ensures this doesn't happen.

Happy to explain further if this explanation's unclear!