### PR TITLE
Maintain scroll position while a textarea is resized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,8 @@ export default function autosize(textarea: HTMLTextAreaElement, {viewportMarginB
     const adjustedViewportMarginBottom = bottom < viewportMarginBottom ? bottom : viewportMarginBottom
     textarea.style.maxHeight = `${maxHeight - adjustedViewportMarginBottom}px`
 
+    const scrollPosition = document.documentElement.scrollTop
+
     const container = textarea.parentElement
     if (container instanceof HTMLElement) {
       const containerHeight = container.style.height
@@ -73,6 +75,7 @@ export default function autosize(textarea: HTMLTextAreaElement, {viewportMarginB
       container.style.height = containerHeight
       const options = map.get(textarea) || {}
       options.previousHeight = textarea.style.height
+      document.documentElement.scrollTop = scrollPosition
     }
 
     const options = map.get(textarea) || {}


### PR DESCRIPTION
If a textarea is positioned near the end of a page, we can get in a situation where we set the height of the textarea to `auto` before setting the correct height. This causes the page to shrink which effectively scrolls the page up for the user. When the textarea then expands, the user is not scrolled back down to the textarea. The user experiences this change as a scroll up movement which is unexpected for them.

This pull request makes the library aware of the user scroll position and makes sure to set the scroll position to what it was before the resizing after the resizing is done.