### PR TITLE
Adds listener for `paste` events.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,7 @@ export default function autosize(textarea, {viewportMarginBottom = 100} = {}) {
   textarea.addEventListener('mousemove', onUserResize)
   textarea.addEventListener('input', sizeToFit)
   textarea.addEventListener('change', sizeToFit)
+  textarea.addEventListenter('paste', sizeToFit)
   const form = textarea.form
   if (form) form.addEventListener('reset', onFormReset)
   if (textarea.value) sizeToFit()
@@ -91,6 +92,7 @@ export default function autosize(textarea, {viewportMarginBottom = 100} = {}) {
       textarea.removeEventListener('mousemove', onUserResize)
       textarea.removeEventListener('input', sizeToFit)
       textarea.removeEventListener('change', sizeToFit)
+      textarea.removeEventListener('paste', sizeToFit)
       if (form) form.removeEventListener('reset', onFormReset)
     }
   }


### PR DESCRIPTION
Small QoL PR that allows the `textarea` node to resize on a `paste` event.

Closes [#1189](https://github.com/github/heart-services/issues/1189)

The `paste` event should be supported in all the browsers we support, let me know if this isn't the case!

In terms of getting this released to npm, do I need to bump any versions in the package.json, or do we have a mechanism to do this automatically?

Thanks!