### PR TITLE
Increase style parsing performance by 2x to 10x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,13 +50,13 @@ export default function autosize(textarea, {viewportMarginBottom = 100} = {}) {
 
     const textareaStyle = getComputedStyle(textarea)
 
-    const topBorderWidth = Number(textareaStyle.borderTopWidth.replace(/px/, ''))
-    const bottomBorderWidth = Number(textareaStyle.borderBottomWidth.replace(/px/, ''))
+    const topBorderWidth = parseFloat(textareaStyle.borderTopWidth)
+    const bottomBorderWidth = parseFloat(textareaStyle.borderBottomWidth)
 
     const isBorderBox = textareaStyle.boxSizing === 'border-box'
     const borderAddOn = isBorderBox ? topBorderWidth + bottomBorderWidth : 0
 
-    const maxHeight = Number(textareaStyle.height.replace(/px/, '')) + bottom
+    const maxHeight = parseFloat(textareaStyle.height) + bottom
     const adjustedViewportMarginBottom = bottom < viewportMarginBottom ? bottom : viewportMarginBottom
     textarea.style.maxHeight = `${maxHeight - adjustedViewportMarginBottom}px`
 


### PR DESCRIPTION
Use `parseFloat` to parse CSS pixel values into `Number`.

This results in a [performance increase](https://perf.link/#eyJpZCI6InFmNmVhMmwzMTNnIiwidGl0bGUiOiIiLCJiZWZvcmUiOiJjb25zdCBkYXRhID0gXCIxMjBweFwiIiwidGVzdHMiOlt7Im5hbWUiOiJUZXN0IENhc2UiLCJjb2RlIjoicGFyc2VGbG9hdChkYXRhKSIsInJ1bnMiOls5ODAwMCwxMDAwMCwxMjYwMDAsMjM1MzAwMCwyNDI2MDAwLDM3MTIwMDAsOTM3MDAwLDEyODUwMDAsMTY0NjAwMCwyMTM5MDAwLDEwMDAwLDI4MzAwMCwxMDI0MDAwLDI0MjAwMDAsMTQyMzAwMCwxMDAwMCw4MDAwMDAsNDMyMDAwLDEwMDAwLDMxNjMwMDAsMTMzMjAwMCw3MDAwMCwxNzgwMDAwLDk4MDAwLDMwMTkwMDAsOTAwMCwxMDAwMCw5MDAwLDE3MjAwMCwxNDE3MDAwLDAsMzM3MjAwMCwyNDQ3MDAwLDE4MTkwMDAsOTEwMDAsOTAwMCw5ODAwMCwxMDAwMCwxMzAwMDAsODkwMDAsMjEyNzAwMCwzMDIwMDAwLDMwMDIwMDAsMTc0NzAwMCw5ODAwMCwxMDAwMCw5MDAwLDkwMDAsMTAwMDAsNDIwMDAwLDE4NDQwMDAsMTI5MzAwMCwxNzY1MDAwLDI2MjUwMDAsMTAwMDAsMjc5MjAwMCw5MTAwMDAsMjM2MTAwMCwxMDAwMCw5MDAwLDE2MzQwMDAsOTgwMDAsMTUwMjAwMCwzMDAwLDkwMDAsOTgwMDAsNTA5MDAwLDkwMDAsOTAwMCwxMDAwMCwxNTY0MDAwLDI1MjMwMDAsODAxMDAwLDk4MDAwLDYzMjAwMCwyMTM3MDAwLDMwMDcwMDAsOTgwMDAsMjg4MzAwMCw5ODAwMCwxNTQwMDAwLDIxODgwMDAsMjQwNzAwMCw5MDAwLDY0MjAwMCw5OTIwMDAsNTU5MDAwLDE2MDAwMCw5ODAwMCw5MDAwLDQzNzAwMCw5MDAwLDkwMDAsMTUzMjAwMCw5MDAwLDkwMDAsNDM3ODAwMCw0NTEwMDAsMTk3OTAwMCwyNzUyMDAwXSwib3BzIjoxMDIyNTAwfSx7Im5hbWUiOiJUZXN0IENhc2UiLCJjb2RlIjoiTnVtYmVyKGRhdGEucmVwbGFjZSgvcHgvLCAnJykpIiwicnVucyI6WzEwMDAwLDkwMDAsMTAwMDAsMzIwMDAsMTM5MDAwLDM3MzAwMCwxMTAwMCwxMTAwMCw5ODAwMCwxMDAwMDAsMTAwMDAsMTEwMDAsMTEwMDAsMTAwMDAwLDI5MDAwLDEwMDAwLDExMDAwLDEwMDAwLDkwMDAsNDE4MDAwLDExMDAwLDkwMDAsMTAwMDAwLDkwMDAsMzk1MDAwLDQ0NzAwMCw5MDAwLDE5NTAwMCwxMDAwMCw3OTAwMCw5MDAwLDQwMDAsMjMyMDAwLDEwMDAwMCwxMDAwLDEwMDAsMTAwMDAsOTAwMCwxMDAwMCwxMDAwMCwxNTQwMDAsMzIxMDAwLDEwMDAsOTUwMDAsMTAwMDAsMjAwMCw5MDAwLDQwMDAsOTAwMCwxMTAwMCw5ODAwMCw1OTAwMCwxMDAwMDAsMTAwMDAwLDQwMDAsMjk3MDAwLDExMDAwLDE2OTAwMCw0ODAwMCwxMTAwMCw4MjAwMCw5MDAwLDg1MDAwLDEwMDAwMCwxMDAwMDAsOTAwMCwxMTAwMCwxMDAwLDEwMDAsOTAwMCw5ODAwMCwxMTYwMDAsMTEwMDAsMTAwMDAsOTAwMCwxMjAwMCwyOTAwMDAsMTExOTAwMCwxMDAwLDEwMDAwLDExMDAwLDEwMDAwMCw3ODIwMDAsMTAwMDAsOTAwMCwxMTAwMCwxMDAwMCwxMDAwMCwxMDAwMCwxMDAwMDAsMTEwMDAsMTAwMCwxMDAwMCwxMDAwMDAsMTUxMDAwLDEwMDAwMCw0OTkwMDAsMTEwMDAsMTAwMDAwLDM1NDAwMF0sIm9wcyI6OTA0ODB9XSwidXBkYXRlZCI6IjIwMjMtMDQtMDhUMTc6MzA6MzcuNDM1WiJ9)  between 2x and 10x according to my testing.