### PR TITLE
Round border widths to nearest int

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,8 @@ export default function autosize(textarea, {viewportMarginBottom = 100} = {}) {
 
     const textareaStyle = getComputedStyle(textarea)
 
-    const topBorderWidth = parseFloat(textareaStyle.borderTopWidth)
-    const bottomBorderWidth = parseFloat(textareaStyle.borderBottomWidth)
+    const topBorderWidth = Math.round(parseFloat(textareaStyle.borderTopWidth))
+    const bottomBorderWidth = Math.round(parseFloat(textareaStyle.borderBottomWidth))
 
     const isBorderBox = textareaStyle.boxSizing === 'border-box'
     const borderAddOn = isBorderBox ? topBorderWidth + bottomBorderWidth : 0

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,8 @@ export default function autosize(textarea, {viewportMarginBottom = 100} = {}) {
 
     const textareaStyle = getComputedStyle(textarea)
 
-    const topBorderWidth = Math.round(parseFloat(textareaStyle.borderTopWidth))
-    const bottomBorderWidth = Math.round(parseFloat(textareaStyle.borderBottomWidth))
+    const topBorderWidth = Math.ceil(parseFloat(textareaStyle.borderTopWidth))
+    const bottomBorderWidth = Math.ceil(parseFloat(textareaStyle.borderBottomWidth))
 
     const isBorderBox = textareaStyle.boxSizing === 'border-box'
     const borderAddOn = isBorderBox ? topBorderWidth + bottomBorderWidth : 0


### PR DESCRIPTION
I'm looking into an [issue](https://github.com/github/primer/issues/2838) (internal-only) one of our team members discovered when they were editing text inside our new comment box. Here's the video from that issue:

https://private-user-images.githubusercontent.com/417268/281561519-2940a25f-b7d9-472d-a535-5e85910d5ad6.mov?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDEyMDczNDEsIm5iZiI6MTcwMTIwNzA0MSwicGF0aCI6Ii80MTcyNjgvMjgxNTYxNTE5LTI5NDBhMjVmLWI3ZDktNDcyZC1hNTM1LTVlODU5MTBkNWFkNi5tb3Y_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBSVdOSllBWDRDU1ZFSDUzQSUyRjIwMjMxMTI4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDIzMTEyOFQyMTMwNDFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT01YjI2ZWUzZjg0MTc1YWY1N2MzYjJjMWY2YjM5MmE5NDg5ZWI3ODljYWYwMzRlNzFiNzRmZWM3ODcwYWRhNDkyJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.q9GGg7QWMgQTBHW588vNJhjT_aUxCu6UbaHnuasuS-Y

_Video description: a person editing text inside a GitHub comment box. As they type, the bottom of the text area jitters up and down on every keystroke._

The text area in the video uses textarea-autosize, and one of our managers noticed the `min-height` occasionally gets set to a subpixel value ending in `.5`, which could explain the jittering.

I haven't been able to reproduce this issue myself, but in reading the code for textarea-autosize, I noticed the use of `parseFloat` and wondered if it could be to blame for the `.5` value in `min-height`.